### PR TITLE
examples/lines.js fix

### DIFF
--- a/examples/lines.js
+++ b/examples/lines.js
@@ -4,8 +4,7 @@
  */
 
 var Canvas = require('../')
-  , tty = require('tty')
-  , size = tty.getWindowSize();
+  , size = process.stdout.getWindowSize();
 
 process.on('SIGINT', function(){
   ctx.reset();
@@ -15,7 +14,7 @@ process.on('SIGINT', function(){
 });
 
 process.on('SIGWINCH', function(){
-  size = tty.getWindowSize();
+  size = process.stdout.getWindowSize();
   canvas.width = size[1];
   canvas.height = size[0];
 });


### PR DESCRIPTION
Retrieve window size using `process.stdout.getWindowSize()` instead of `require('tty').getWindowSize();`
