### PR TITLE
add toggleForegroundBold method to 2d canvas

### DIFF
--- a/lib/context2d.js
+++ b/lib/context2d.js
@@ -481,6 +481,12 @@ Context2d.prototype.applyForegroundFillStyle = function(){
   this.write('\033[3' + color + 'm');
 };
 
+Context2d.prototype.toggleForegroundBold = function(){
+  foregroundBold = (this.state().foregroundBold + 1) % 2;
+  this.write('\033[' + foregroundBold + 'm');
+  this.state().foregroundBold = foregroundBold;
+};
+
 /**
  * Apply the current fill style.
  *

--- a/lib/state.js
+++ b/lib/state.js
@@ -16,4 +16,5 @@ function State() {
   this.scaleY = 1;
   this.translateX = 0;
   this.translateY = 0;
+  this.foregroundBold = 0;
 }


### PR DESCRIPTION
In most terminals, bold foreground also makes the color lighter, so this also doubles the choices of color we have.
